### PR TITLE
設定画面の作成

### DIFF
--- a/native/app/(tabs)/settings.tsx
+++ b/native/app/(tabs)/settings.tsx
@@ -1,9 +1,102 @@
-import { View, Text } from "react-native";
+import { useNavigation } from "@react-navigation/native";
+import {
+  Alert,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+
+const settingsItems = [
+  { label: "プロフィール", screen: "profile" },
+  { label: "アカウント情報", screen: "account" },
+  { label: "ユーザー管理", screen: "userManagement" },
+  { label: "お知らせ", screen: "notice" },
+  { label: "利用規約", screen: "terms" },
+  { label: "バージョン情報", screen: "version" },
+  { label: "ログアウト", screen: "logout" },
+];
 
 export default function SettingsScreen() {
+  const navigation = useNavigation();
   return (
-    <View style={{ flex: 1, alignItems: "center", justifyContent: "center" }}>
-      <Text>設定</Text>
+    <View style={styles.container}>
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        <View style={{ height: 50 }} />
+        {settingsItems.map((item, idx) => {
+          if (item.label === "ログアウト") {
+            return (
+              <TouchableOpacity
+                key={item.label}
+                style={styles.item}
+                onPress={() => {
+                  Alert.alert("ログアウト", "本当にログアウトしますか？", [
+                    { text: "キャンセル", style: "cancel" },
+                    {
+                      text: "ログアウトする",
+                      style: "destructive",
+                      onPress: () => {
+                        /* ログアウト処理 */
+                      },
+                    },
+                  ]);
+                }}
+              >
+                <Text style={styles.logoutText}>{item.label}</Text>
+              </TouchableOpacity>
+            );
+          }
+          return (
+            <TouchableOpacity
+              key={item.label}
+              style={styles.item}
+              onPress={() => navigation.navigate(item.screen as never)}
+            >
+              <View style={styles.itemRow}>
+                <Text style={styles.itemText}>{item.label}</Text>
+                <Text style={styles.chevron}>{">"}</Text>
+              </View>
+            </TouchableOpacity>
+          );
+        })}
+      </ScrollView>
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#fff",
+  },
+  scrollContent: {
+    paddingVertical: 16,
+  },
+  item: {
+    borderBottomWidth: 1,
+    borderBottomColor: "#ccc",
+    paddingVertical: 18,
+    paddingHorizontal: 20,
+    backgroundColor: "#fff",
+  },
+  itemRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  itemText: {
+    fontSize: 16,
+    color: "#222",
+  },
+  chevron: {
+    fontSize: 18,
+    color: "#bbb",
+    marginLeft: 8,
+  },
+  logoutText: {
+    fontSize: 16,
+    color: "#d32f2f",
+    textAlign: "left",
+  },
+});

--- a/native/app/_layout.tsx
+++ b/native/app/_layout.tsx
@@ -1,15 +1,19 @@
-import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
-import { useFonts } from 'expo-font';
-import { Stack } from 'expo-router';
-import { StatusBar } from 'expo-status-bar';
-import 'react-native-reanimated';
+import {
+  DarkTheme,
+  DefaultTheme,
+  ThemeProvider,
+} from "@react-navigation/native";
+import { useFonts } from "expo-font";
+import { Stack } from "expo-router";
+import { StatusBar } from "expo-status-bar";
+import "react-native-reanimated";
 
-import { useColorScheme } from '@/hooks/useColorScheme';
+import { useColorScheme } from "@/hooks/useColorScheme";
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();
   const [loaded] = useFonts({
-    SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
+    SpaceMono: require("../assets/fonts/SpaceMono-Regular.ttf"),
   });
 
   if (!loaded) {
@@ -18,9 +22,18 @@ export default function RootLayout() {
   }
 
   return (
-    <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+    <ThemeProvider value={colorScheme === "dark" ? DarkTheme : DefaultTheme}>
       <Stack>
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        <Stack.Screen name="profile" options={{ title: "プロフィール" }} />
+        <Stack.Screen name="account" options={{ title: "アカウント情報" }} />
+        <Stack.Screen
+          name="userManagement"
+          options={{ title: "ユーザー管理" }}
+        />
+        <Stack.Screen name="notice" options={{ title: "お知らせ" }} />
+        <Stack.Screen name="terms" options={{ title: "利用規約" }} />
+        <Stack.Screen name="version" options={{ title: "バージョン情報" }} />
         <Stack.Screen name="+not-found" />
       </Stack>
       <StatusBar style="auto" />

--- a/native/app/account.tsx
+++ b/native/app/account.tsx
@@ -1,0 +1,151 @@
+import { useNavigation } from "@react-navigation/native";
+import React, { useLayoutEffect, useState } from "react";
+import {
+  Alert,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from "react-native";
+
+export default function AccountScreen() {
+  const navigation = useNavigation();
+  const [email, setEmail] = useState("user@example.com"); // 仮の初期値
+  const [phone, setPhone] = useState("");
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+
+  useLayoutEffect(() => {
+    navigation.setOptions({ headerBackTitle: "設定" });
+  }, [navigation]);
+
+  const handleDeleteAccount = () => {
+    Alert.alert(
+      "アカウント削除",
+      "本当にアカウントを削除しますか？この操作は取り消せません。",
+      [
+        { text: "キャンセル", style: "cancel" },
+        {
+          text: "削除する",
+          style: "destructive",
+          onPress: () => {
+            /* 削除処理 */
+          },
+        },
+      ],
+    );
+  };
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <Text style={styles.label}>メールアドレス</Text>
+      <View style={styles.row}>
+        <Text style={styles.emailText}>{email}</Text>
+        <TouchableOpacity style={styles.changeButton}>
+          <Text style={styles.changeButtonText}>変更</Text>
+        </TouchableOpacity>
+      </View>
+
+      <Text style={styles.label}>パスワードの変更</Text>
+      <TextInput
+        style={styles.input}
+        value={currentPassword}
+        onChangeText={setCurrentPassword}
+        placeholder="現在のパスワード"
+        secureTextEntry
+      />
+      <TextInput
+        style={styles.input}
+        value={newPassword}
+        onChangeText={setNewPassword}
+        placeholder="新しいパスワード"
+        secureTextEntry
+      />
+      <TextInput
+        style={styles.input}
+        value={confirmPassword}
+        onChangeText={setConfirmPassword}
+        placeholder="新しいパスワード（確認用）"
+        secureTextEntry
+      />
+
+      <Text style={styles.label}>電話番号（任意）</Text>
+      <TextInput
+        style={styles.input}
+        value={phone}
+        onChangeText={setPhone}
+        placeholder="電話番号を入力"
+        keyboardType="phone-pad"
+      />
+
+      <TouchableOpacity
+        style={styles.deleteButton}
+        onPress={handleDeleteAccount}
+      >
+        <Text style={styles.deleteButtonText}>アカウントの削除</Text>
+      </TouchableOpacity>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 24,
+    backgroundColor: "#fff",
+    minHeight: "100%",
+  },
+  label: {
+    fontSize: 15,
+    fontWeight: "bold",
+    marginBottom: 6,
+    marginTop: 18,
+    color: "#222",
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: "#ccc",
+    borderRadius: 8,
+    padding: 10,
+    fontSize: 15,
+    backgroundColor: "#fafafa",
+    marginBottom: 8,
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginBottom: 8,
+  },
+  emailText: {
+    fontSize: 15,
+    color: "#222",
+  },
+  changeButton: {
+    backgroundColor: "#eee",
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 8,
+  },
+  changeButtonText: {
+    color: "#1976d2",
+    fontWeight: "bold",
+    fontSize: 14,
+  },
+  deleteButton: {
+    marginTop: 32,
+    backgroundColor: "#fff",
+    borderWidth: 1,
+    borderColor: "#d32f2f",
+    borderRadius: 8,
+    paddingVertical: 12,
+    alignItems: "center",
+  },
+  deleteButtonText: {
+    color: "#d32f2f",
+    fontWeight: "bold",
+    fontSize: 15,
+  },
+});

--- a/native/app/notice.tsx
+++ b/native/app/notice.tsx
@@ -1,0 +1,103 @@
+import { useNavigation } from "@react-navigation/native";
+import React, { useLayoutEffect, useState } from "react";
+import {
+  ScrollView,
+  StyleSheet,
+  Switch,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+
+const notices = [
+  { id: 1, title: "新機能リリースのお知らせ", date: "2025/08/01" },
+  { id: 2, title: "メンテナンスのお知らせ", date: "2025/07/15" },
+  { id: 3, title: "利用規約改定", date: "2025/07/01" },
+];
+
+export default function NoticeScreen() {
+  const navigation = useNavigation();
+  const [eventPush, setEventPush] = useState(true);
+  const [adminPush, setAdminPush] = useState(false);
+
+  useLayoutEffect(() => {
+    navigation.setOptions({ headerBackTitle: "設定" });
+  }, [navigation]);
+
+  const handleNoticePress = (noticeId: number) => {
+    // 詳細ページへ遷移（仮）
+    // navigation.navigate("NoticeDetail" as never, { id: noticeId } as never);
+  };
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <Text style={styles.label}>お知らせ一覧</Text>
+      <View style={styles.noticeList}>
+        {notices.map((notice) => (
+          <TouchableOpacity
+            key={notice.id}
+            style={styles.noticeItem}
+            onPress={() => handleNoticePress(notice.id)}
+          >
+            <View>
+              <Text style={styles.noticeTitle}>{notice.title}</Text>
+              <Text style={styles.noticeDate}>{notice.date}</Text>
+            </View>
+          </TouchableOpacity>
+        ))}
+      </View>
+
+      <Text style={styles.label}>プッシュ通知設定</Text>
+      <View style={styles.switchRow}>
+        <Text style={styles.switchLabel}>イベント関連の通知</Text>
+        <Switch value={eventPush} onValueChange={setEventPush} />
+      </View>
+      <View style={styles.switchRow}>
+        <Text style={styles.switchLabel}>運営からのお知らせ</Text>
+        <Switch value={adminPush} onValueChange={setAdminPush} />
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 24,
+    backgroundColor: "#fff",
+    minHeight: "100%",
+  },
+  label: {
+    fontSize: 15,
+    fontWeight: "bold",
+    marginBottom: 6,
+    marginTop: 18,
+    color: "#222",
+  },
+  noticeList: {
+    marginBottom: 8,
+  },
+  noticeItem: {
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+    borderBottomColor: "#eee",
+  },
+  noticeTitle: {
+    fontSize: 15,
+    color: "#222",
+  },
+  noticeDate: {
+    fontSize: 12,
+    color: "#888",
+    marginTop: 2,
+  },
+  switchRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginBottom: 8,
+  },
+  switchLabel: {
+    fontSize: 15,
+    color: "#222",
+  },
+});

--- a/native/app/profile.tsx
+++ b/native/app/profile.tsx
@@ -1,0 +1,82 @@
+import { useNavigation } from "@react-navigation/native";
+import React, { useLayoutEffect, useState } from "react";
+import { ScrollView, StyleSheet, Text, TextInput } from "react-native";
+
+export default function ProfileScreen() {
+  const navigation = useNavigation();
+  const [nickname, setNickname] = useState("");
+  const [bio, setBio] = useState("");
+  const [gender, setGender] = useState("");
+  const [sns, setSNS] = useState("");
+
+  useLayoutEffect(() => {
+    navigation.setOptions({ headerBackTitle: "設定" });
+  }, [navigation]);
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <Text style={styles.label}>ニックネーム</Text>
+      <TextInput
+        style={styles.input}
+        value={nickname}
+        onChangeText={setNickname}
+        placeholder="ニックネームを入力"
+      />
+
+      <Text style={styles.label}>自己紹介文</Text>
+      <TextInput
+        style={[styles.input, styles.textarea]}
+        value={bio}
+        onChangeText={setBio}
+        placeholder="自己紹介文を入力"
+        multiline
+      />
+
+      <Text style={styles.label}>性別</Text>
+      <TextInput
+        style={styles.input}
+        value={gender}
+        onChangeText={setGender}
+        placeholder="男性・女性・その他・回答しない など"
+      />
+
+      <Text style={styles.label}>SNSリンク</Text>
+      <TextInput
+        style={styles.input}
+        value={sns}
+        onChangeText={setSNS}
+        placeholder="XやInstagramなどのURLを入力"
+        autoCapitalize="none"
+        autoCorrect={false}
+      />
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 24,
+    backgroundColor: "#fff",
+    minHeight: "100%",
+  },
+  label: {
+    fontSize: 15,
+    fontWeight: "bold",
+    marginBottom: 6,
+    marginTop: 18,
+    color: "#222",
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: "#ccc",
+    borderRadius: 8,
+    padding: 10,
+    fontSize: 15,
+    backgroundColor: "#fafafa",
+    marginBottom: 8,
+  },
+  textarea: {
+    height: 80,
+    textAlignVertical: "top",
+  },
+});

--- a/native/app/terms.tsx
+++ b/native/app/terms.tsx
@@ -1,0 +1,64 @@
+import { useNavigation } from "@react-navigation/native";
+import React, { useLayoutEffect } from "react";
+import {
+  Linking,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+} from "react-native";
+
+const TERMS_TEXT = `第1条（目的）\n本サービスは...（ここに利用規約全文を記載）\n\n第2条（禁止事項）\n...`;
+const PRIVACY_POLICY_URL = "https://example.com/privacy";
+
+export default function TermsScreen() {
+  const navigation = useNavigation();
+
+  useLayoutEffect(() => {
+    navigation.setOptions({ headerBackTitle: "設定" });
+  }, [navigation]);
+
+  const handlePrivacyPress = () => {
+    Linking.openURL(PRIVACY_POLICY_URL);
+  };
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <Text style={styles.label}>利用規約</Text>
+      <Text style={styles.termsText}>{TERMS_TEXT}</Text>
+
+      <TouchableOpacity style={styles.privacyLink} onPress={handlePrivacyPress}>
+        <Text style={styles.privacyText}>プライバシーポリシーはこちら</Text>
+      </TouchableOpacity>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 24,
+    backgroundColor: "#fff",
+    minHeight: "100%",
+  },
+  label: {
+    fontSize: 15,
+    fontWeight: "bold",
+    marginBottom: 6,
+    marginTop: 18,
+    color: "#222",
+  },
+  termsText: {
+    fontSize: 14,
+    color: "#222",
+    lineHeight: 22,
+    marginBottom: 24,
+  },
+  privacyLink: {
+    paddingVertical: 12,
+  },
+  privacyText: {
+    color: "#1976d2",
+    fontSize: 15,
+    textDecorationLine: "underline",
+  },
+});

--- a/native/app/version.tsx
+++ b/native/app/version.tsx
@@ -1,0 +1,83 @@
+import { useNavigation } from "@react-navigation/native";
+import React, { useLayoutEffect } from "react";
+import {
+  Linking,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+} from "react-native";
+
+const APP_VERSION = "1.0.0";
+const STORE_URL = "https://apps.apple.com/jp/app/id000000000"; // 仮URL
+const LICENSE_URL = "https://example.com/licenses";
+
+export default function VersionScreen() {
+  const navigation = useNavigation();
+
+  useLayoutEffect(() => {
+    navigation.setOptions({ headerBackTitle: "設定" });
+  }, [navigation]);
+
+  const handleStorePress = () => {
+    Linking.openURL(STORE_URL);
+  };
+  const handleLicensePress = () => {
+    Linking.openURL(LICENSE_URL);
+  };
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <Text style={styles.label}>現在のバージョン</Text>
+      <Text style={styles.versionText}>バージョン {APP_VERSION}</Text>
+
+      <TouchableOpacity style={styles.updateButton} onPress={handleStorePress}>
+        <Text style={styles.updateButtonText}>アップデートを確認</Text>
+      </TouchableOpacity>
+
+      <TouchableOpacity style={styles.licenseLink} onPress={handleLicensePress}>
+        <Text style={styles.licenseText}>ライセンス情報はこちら</Text>
+      </TouchableOpacity>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 24,
+    backgroundColor: "#fff",
+    minHeight: "100%",
+  },
+  label: {
+    fontSize: 15,
+    fontWeight: "bold",
+    marginBottom: 6,
+    marginTop: 18,
+    color: "#222",
+  },
+  versionText: {
+    fontSize: 16,
+    color: "#222",
+    marginBottom: 24,
+  },
+  updateButton: {
+    backgroundColor: "#1976d2",
+    borderRadius: 8,
+    paddingVertical: 12,
+    alignItems: "center",
+    marginBottom: 16,
+  },
+  updateButtonText: {
+    color: "#fff",
+    fontSize: 15,
+    fontWeight: "bold",
+  },
+  licenseLink: {
+    paddingVertical: 12,
+  },
+  licenseText: {
+    color: "#1976d2",
+    fontSize: 15,
+    textDecorationLine: "underline",
+  },
+});


### PR DESCRIPTION
- Closes #18 

## 実装したこと

- [x]  設定画面の実装
- [x] プロフィールの実装
- [x] アカウント情報の実装
- [x] ユーザー管理は項目のみ作成。タップした時の詳細画面は未実装
- [x] お知らせの実装
- [x] 利用規約の実装
- [x] バージョン情報の実装
- [x] ログアウトの実装

## 補足
- 作成されたデザイン画面に従って、「ヘッダー」「アプリ使い方(8.19 google.docsに記載あり)」は作成していない
- 「ユーザー管理」について、具体的な詳細が思いつかなかったため、項目だけの作成となった
- デザインとして、設定項目のグループ分け（例：アカウント設定→プロフィール・アカウント情報、アプリ情報→お知らせ・利用規約・バージョン情報、アクション→ログアウト）、アイコンの追加をすると良いかなと個人的に思った

## 実装画面
<details>
<summary>スクリーンショット（クリックで展開）</summary>

| 設定画面 | プロフィール |
| --- | --- |
| <img width="400" height="829" alt="スクリーンショット 2025-08-24 4 16 50" src="https://github.com/user-attachments/assets/ed9fd241-6134-442a-aa16-f08f18c55b09" /> | <img width="400" height="829" alt="スクリーンショット 2025-08-24 4 17 43" src="https://github.com/user-attachments/assets/aa3d1025-f88b-4bc6-930c-a18c1384610f" /> |

| アカウント情報 | ユーザー管理 |
| --- | --- |
| <img width="408" height="831" alt="スクリーンショット 2025-08-24 4 21 23" src="https://github.com/user-attachments/assets/f32074c1-330c-4ea0-9014-5d09f1842815" /> | 未実装 |

| お知らせ | 利用規約 |
| --- | --- |
| <img width="401" height="826" alt="スクリーンショット 2025-08-24 4 21 51" src="https://github.com/user-attachments/assets/18ec4a96-5f5d-460c-906b-983c5636fecf" /> | <img width="406" height="832" alt="スクリーンショット 2025-08-24 4 22 18" src="https://github.com/user-attachments/assets/d7fd4d32-e3a5-42f4-a9bf-8d76deb65a40" /> |
  
| バージョン情報 | ログアウト |
| --- | --- |
| <img width="404" height="827" alt="スクリーンショット 2025-08-24 4 22 38" src="https://github.com/user-attachments/assets/e9e645cf-60a3-4bbb-a26e-e40e44460daa" /> | <img width="400" height="836" alt="スクリーンショット 2025-08-24 4 23 03" src="https://github.com/user-attachments/assets/9f567187-5ff1-42e3-8f1e-cd6bc4b7ab3f" /> |

</details>