### PR TITLE
予約一覧画面の修正

### DIFF
--- a/native/app/(tabs)/_layout.tsx
+++ b/native/app/(tabs)/_layout.tsx
@@ -18,7 +18,7 @@ export default function TabLayout() {
       />
       <Tabs.Screen
         name="bookings"
-        options={{ title: "予約一覧", headerShown: false }}
+        options={{ title: "予約一覧", headerShown: true }}
       />
       <Tabs.Screen
         name="settings"

--- a/native/app/(tabs)/bookings.tsx
+++ b/native/app/(tabs)/bookings.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import {
+  Alert,
   Modal,
   Pressable,
   ScrollView,
@@ -10,56 +11,178 @@ import {
 } from "react-native";
 
 // サンプルデータ
-const bookings = [
+const initialBookings = [
   {
     id: 1,
-    title: "イベントA",
-    age: "25",
-    gender: "男性のみ",
-    date: "2025/08/20",
-    place: "東京都渋谷区",
-    people: "10人",
+    name: "React Native もくもく会@渋谷",
+    description:
+      "アプリ開発者やデザイナーが集まって、各自の作業を進める会です。初心者も歓迎！",
+    location: "TECH BISTRO SHIBUYA",
+    start_at: "2025/09/15 19:00",
+    end_at: "2025/09/15 21:30",
+    status: "開催前",
   },
   {
     id: 2,
-    title: "イベントB",
-    age: "30",
-    gender: "制限なし",
-    date: "2025/08/22",
-    place: "大阪府大阪市",
-    people: "5人",
+    name: "スタートアップのための資金調達セミナー",
+    description:
+      "VCからの資金調達のノウハウや、魅力的な事業計画書の作り方を解説します。",
+    location: "ナレッジベース大阪 カンファレンスルームB",
+    start_at: "2025/08/25 14:00",
+    end_at: "2025/08/25 16:00",
+    status: "終了",
+  },
+];
+
+const initialInvites = [
+  {
+    id: 101,
+    name: "新規イベントの招待",
+    description: "あああ",
+    location: "新宿コワーキングスペース",
+    start_at: "2025/09/20 18:00",
+    end_at: "2025/09/20 20:00",
+    status: "招待中",
   },
 ];
 
 export default function BookingsScreen() {
   const [selectedId, setSelectedId] = useState<number | null>(null);
+  const [activeTab, setActiveTab] = useState<"bookings" | "invites">(
+    "bookings",
+  );
+  const [bookings, setBookings] = useState(initialBookings);
+  const [invites, setInvites] = useState(initialInvites);
+  // お知らせ（DBから取得する想定）
+  const [notice, setNotice] = useState<string>("");
 
-  const selectedBooking = bookings.find((b) => b.id === selectedId);
+  React.useEffect(() => {
+    // 仮: DBから取得する処理
+    if (selectedId !== null) {
+      // ここでAPI等から取得する
+      // 例: fetchNotice(selectedId).then(setNotice)
+      // 今はダミー
+      setNotice("イベントに関する最新のお知らせが表示されます。");
+    } else {
+      setNotice("");
+    }
+  }, [selectedId]);
+
+  // タブごとに表示するリストを切り替え
+  const eventList = activeTab === "bookings" ? bookings : invites;
+  const selectedBooking = eventList.find((b) => b.id === selectedId);
+
+  // 予約を取り消す
+  const handleCancelBooking = () => {
+    if (!selectedBooking) return;
+    Alert.alert(
+      "予約を取り消しますか？",
+      "本当にこのイベントの予約を取り消しますか？",
+      [
+        { text: "キャンセル", style: "cancel" },
+        {
+          text: "取り消す",
+          style: "destructive",
+          onPress: () => {
+            setBookings(bookings.filter((b) => b.id !== selectedBooking.id));
+            setSelectedId(null);
+          },
+        },
+      ],
+    );
+  };
+
+  // 招待イベントに「参加」
+  const handleAcceptInvite = () => {
+    if (!selectedBooking) return;
+    setBookings([...bookings, selectedBooking]);
+    setInvites(invites.filter((b) => b.id !== selectedBooking.id));
+    setSelectedId(null);
+  };
+
+  // 招待イベントに「不参加」
+  const handleDeclineInvite = () => {
+    if (!selectedBooking) return;
+    setInvites(invites.filter((b) => b.id !== selectedBooking.id));
+    setSelectedId(null);
+  };
 
   return (
     <View style={styles.container}>
-      {/* ヘッダー */}
-      <View style={styles.header}>
-        <Text style={styles.headerText}>予約一覧</Text>
+      {/* タブ切り替え */}
+      <View style={styles.tabContainer}>
+        <TouchableOpacity
+          style={[
+            styles.tabButton,
+            activeTab === "bookings" && styles.tabActive,
+          ]}
+          onPress={() => {
+            setActiveTab("bookings");
+            setSelectedId(null);
+          }}
+        >
+          <Text
+            style={[
+              styles.tabText,
+              activeTab === "bookings" && styles.tabTextActive,
+            ]}
+          >
+            予約済み
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[
+            styles.tabButton,
+            activeTab === "invites" && styles.tabActive,
+          ]}
+          onPress={() => {
+            setActiveTab("invites");
+            setSelectedId(null);
+          }}
+        >
+          <Text
+            style={[
+              styles.tabText,
+              activeTab === "invites" && styles.tabTextActive,
+            ]}
+          >
+            招待
+          </Text>
+        </TouchableOpacity>
       </View>
-      {/* 予約リスト */}
-      <ScrollView contentContainerStyle={styles.listContainer}>
-        {bookings.map((booking) => {
-          const isSelected = selectedId === booking.id;
-          return (
-            <TouchableOpacity
-              key={booking.id}
-              style={[styles.card, isSelected && styles.selectedCard]}
-              activeOpacity={0.8}
-              onPress={() => setSelectedId(booking.id)}
-            >
-              <Text style={styles.cardTitle}>{booking.title}</Text>
-              <Text style={styles.cardDate}>{booking.date}</Text>
-              <Text style={styles.detailLink}>詳細を見る</Text>
-            </TouchableOpacity>
-          );
-        })}
-      </ScrollView>
+
+      {/* リスト表示 */}
+      {eventList.length === 0 ? (
+        <View style={styles.emptyContainer}>
+          <Text style={styles.emptyText}>
+            {activeTab === "bookings"
+              ? "予約済みのイベントはありません"
+              : "招待されたイベントはありません"}
+          </Text>
+        </View>
+      ) : (
+        <ScrollView contentContainerStyle={styles.listContainer}>
+          {eventList.map((booking) => {
+            const isSelected = selectedId === booking.id;
+            return (
+              <TouchableOpacity
+                key={booking.id}
+                style={[styles.card, isSelected && styles.selectedCard]}
+                activeOpacity={0.8}
+                onPress={() => setSelectedId(booking.id)}
+              >
+                <Text style={styles.cardTitle}>{booking.name}</Text>
+                <Text style={styles.cardDate}>開始: {booking.start_at}</Text>
+                <Text style={styles.cardDate}>終了: {booking.end_at}</Text>
+                <Text style={styles.cardlocation}>
+                  場所: {booking.location}
+                </Text>
+              </TouchableOpacity>
+            );
+          })}
+        </ScrollView>
+      )}
+
       {/* 詳細表示 */}
       <Modal
         visible={selectedId !== null}
@@ -74,23 +197,51 @@ export default function BookingsScreen() {
           <View style={styles.modalContent}>
             {selectedBooking && (
               <>
-                <Text style={styles.modalTitle}>{selectedBooking.title}</Text>
+                <Text style={styles.modalTitle}>{selectedBooking.name}</Text>
                 <Text style={styles.modalItem}>
-                  年齢: {selectedBooking.age}
+                  開始日時: {selectedBooking.start_at}
                 </Text>
                 <Text style={styles.modalItem}>
-                  性別: {selectedBooking.gender}
+                  終了日時: {selectedBooking.end_at}
                 </Text>
                 <Text style={styles.modalItem}>
-                  日程: {selectedBooking.date}
+                  場所: {selectedBooking.location}
+                </Text>
+                <View style={{ height: 12 }} />
+                <Text style={styles.modalItem}>
+                  説明: {selectedBooking.description}
                 </Text>
                 <Text style={styles.modalItem}>
-                  場所: {selectedBooking.place}
+                  ステータス: {selectedBooking.status}
                 </Text>
-                <Text style={styles.modalItem}>
-                  人数: {selectedBooking.people}
-                </Text>
-                <Text style={styles.modalHint}>タップで詳細を閉じる</Text>
+                <View style={{ height: 8 }} />
+                <Text style={styles.modalNoticeTitle}>お知らせ</Text>
+                <Text style={styles.modalNotice}>{notice}</Text>
+
+                {/* ボタン群 */}
+                {activeTab === "bookings" ? (
+                  <TouchableOpacity
+                    style={styles.cancelButton}
+                    onPress={handleCancelBooking}
+                  >
+                    <Text style={styles.cancelButtonText}>予約を取り消す</Text>
+                  </TouchableOpacity>
+                ) : (
+                  <View style={styles.inviteButtonRow}>
+                    <TouchableOpacity
+                      style={[styles.inviteButton, styles.inviteAccept]}
+                      onPress={handleAcceptInvite}
+                    >
+                      <Text style={styles.inviteButtonText}>参加</Text>
+                    </TouchableOpacity>
+                    <TouchableOpacity
+                      style={[styles.inviteButton, styles.inviteDecline]}
+                      onPress={handleDeclineInvite}
+                    >
+                      <Text style={styles.inviteButtonText}>不参加</Text>
+                    </TouchableOpacity>
+                  </View>
+                )}
               </>
             )}
           </View>
@@ -101,25 +252,106 @@ export default function BookingsScreen() {
 }
 
 const styles = StyleSheet.create({
+  modalNoticeTitle: {
+    fontSize: 15,
+    fontWeight: "bold",
+    color: "#000000ff",
+    marginBottom: 4,
+  },
+  modalNotice: {
+    fontSize: 15,
+    color: "#222",
+    marginBottom: 8,
+  },
+  cancelButton: {
+    marginTop: 24,
+    backgroundColor: "#F44336",
+    borderRadius: 8,
+    paddingVertical: 12,
+    alignItems: "center",
+  },
+  cancelButtonText: {
+    color: "#fff",
+    fontSize: 16,
+    fontWeight: "bold",
+  },
+  inviteButtonRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    marginTop: 24,
+  },
+  inviteButton: {
+    flex: 1,
+    borderRadius: 8,
+    paddingVertical: 12,
+    alignItems: "center",
+    marginHorizontal: 4,
+  },
+  inviteAccept: {
+    backgroundColor: "#2196F3",
+  },
+  inviteDecline: {
+    backgroundColor: "#BDBDBD",
+  },
+  inviteButtonText: {
+    color: "#fff",
+    fontSize: 16,
+    fontWeight: "bold",
+  },
+  tabContainer: {
+    flexDirection: "row",
+    backgroundColor: "#E3F2FD",
+    borderRadius: 8,
+    margin: 16,
+    marginBottom: 0,
+    overflow: "hidden",
+  },
+  tabButton: {
+    flex: 1,
+    paddingVertical: 12,
+    alignItems: "center",
+    backgroundColor: "#E3F2FD",
+  },
+  tabActive: {
+    backgroundColor: "#2196F3",
+  },
+  tabText: {
+    fontSize: 16,
+    color: "#2196F3",
+    fontWeight: "bold",
+  },
+  tabTextActive: {
+    color: "#fff",
+  },
+  cardlocation: {
+    fontSize: 15,
+    color: "#666",
+    marginBottom: 4,
+  },
+  cardStatus: {
+    fontSize: 15,
+    color: "#2196F3",
+    fontWeight: "bold",
+    marginBottom: 4,
+    textAlign: "right",
+  },
+  emptyContainer: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  emptyText: {
+    fontSize: 17,
+    color: "#888",
+    textAlign: "center",
+  },
   container: {
     flex: 1,
     backgroundColor: "#F7F9FB",
   },
-  header: {
-    paddingTop: 48,
-    paddingBottom: 16,
-    backgroundColor: "#fff",
-    alignItems: "center",
-    borderBottomWidth: 1,
-    borderBottomColor: "#E0E0E0",
-  },
-  headerText: {
-    fontSize: 24,
-    fontWeight: "bold",
-    color: "#222",
-  },
   listContainer: {
     padding: 16,
+    paddingTop: 16,
   },
   card: {
     backgroundColor: "#fff",
@@ -166,6 +398,7 @@ const styles = StyleSheet.create({
     borderRadius: 16,
     padding: 28,
     minWidth: 280,
+    marginHorizontal: 24,
     shadowColor: "#000",
     shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.15,
@@ -175,7 +408,7 @@ const styles = StyleSheet.create({
   modalTitle: {
     fontSize: 22,
     fontWeight: "bold",
-    color: "#2196F3",
+    color: "#222",
     marginBottom: 16,
     textAlign: "center",
   },

--- a/native/app/_layout.tsx
+++ b/native/app/_layout.tsx
@@ -32,7 +32,6 @@ export default function RootLayout() {
           <Stack.Screen name="notice" options={{ title: "お知らせ" }} />
           <Stack.Screen name="help" options={{ title: "ヘルプセンター" }} />
           <Stack.Screen name="terms" options={{ title: "利用規約" }} />
-          <Stack.Screen name="version" options={{ title: "バージョン情報" }} />
           <Stack.Screen name="+not-found" />
         </Stack>
         <StatusBar style="auto" />

--- a/native/components/ui/BottomNavigation.tsx
+++ b/native/components/ui/BottomNavigation.tsx
@@ -51,10 +51,12 @@ export default function BottomNavigation({
                 style={styles.tabButton}
                 onPress={() => handleTabPress(tab.key, index)}
               >
-                <Icon
-                  size={24}
-                  color={isActive ? colors.active : colors.inactive}
-                />
+                {Icon && (
+                  <Icon
+                    size={24}
+                    color={isActive ? colors.active : colors.inactive}
+                  />
+                )}
                 <Text
                   style={[
                     styles.tabLabel,


### PR DESCRIPTION
- Fixes #24 

## 修正したこと

前回から大きく変更したので要点だけ
- [x] 「予約済み」と「招待」の2つのタブに分けてイベントを表示
- [x] カードには「イベントタイトル・開始時間・終了時間・場所」の4つの情報を表示（Slackで話してたやつ）
- [x] 詳細（カードをタップ）には、上記に加えて「説明・ステータス・お知らせ」の3つの情報を追加で表示。「ステータス」に関しては、そもそも必要か？or 表示方法を変える（例：開催中ならばカードの右上にポップを出すとか）にするかも

## 補足
- DB接続は次回の修正でやります。今回はUIだけ
- 「設定」画面でまだエラーが1つありますが、そのエラーはDBと接続すれば解決する見込みです。DB接続をお待ちください
- 今気づいたのだが、企画したイベントの修正ボタンとかがあったほうが良かったかな？いや、それは主催者の作業だから「繋がる」画面にあるほうが適切か？→お知らせがあるから、最悪なくても良いかとも思ったり...

## 実装画面
<details>
<summary>スクリーンショット（クリックで展開）</summary>

| 予約済み | （詳細） |
| --- | --- |
| <img width="403" height="835" alt="スクリーンショット 2025-09-02 3 46 46" src="https://github.com/user-attachments/assets/e38fac34-b77f-4f89-a9e6-aac3aa946ed9" /> | <img width="400" height="836" alt="スクリーンショット 2025-09-02 3 47 18" src="https://github.com/user-attachments/assets/dc997664-25fe-4062-ab49-517e18acf53b" /> |

| 招待 | （詳細） |
| --- | --- |
| <img width="412" height="835" alt="スクリーンショット 2025-09-02 3 47 48" src="https://github.com/user-attachments/assets/e54e37d3-027f-414a-b56f-cfdac0550c9f" /> | <img width="407" height="832" alt="スクリーンショット 2025-09-02 3 48 08" src="https://github.com/user-attachments/assets/25b657f6-df41-446e-861b-ef6c60587598" /> |

</details>