### PR TITLE
ブランチ: 見るにおいて参加ボタンとDBからのイベント情報の取得

### DIFF
--- a/native/app/(tabs)/see.tsx
+++ b/native/app/(tabs)/see.tsx
@@ -210,6 +210,15 @@ export default function App() {
   // ピン押下 → すぐモーダル
   const handleMarkerPress = useCallback((pin: Pin) => {
     setSelectedEvent(pin);
+    mapRef.current?.animateToRegion(
+      {
+        latitude: pin.latitude,
+        longitude: pin.longitude,
+        latitudeDelta: 0.1, // smaller value = more zoom
+        longitudeDelta: 0.1,
+      },
+      500, // duration in ms
+    );
   }, []);
 
   // 追従ON/OFF


### PR DESCRIPTION
## イベント参加機能の追加・改善 (`see.tsx`)

### 概要
- イベント詳細モーダルに「participate」ボタンを追加
- 参加ボタン押下時に確認ダイアログを表示
- Supabaseの`event_members`テーブルを参照し、未参加の場合のみ参加者として追加
- 既に参加済みの場合は警告を表示
- 参加処理後に「参加しました！」と通知

### 主な変更点
- `handleParticipate`関数を追加し、イベント参加ロジックを実装
- 「participate」ボタン押下時に`Alert.alert`で確認ダイアログを表示
- 参加済みチェック・追加処理をSupabase経由で実行
- UI/UX向上のため、ボタン配置やモーダル内レイアウトも調整

### 動作確認方法
1. 任意のイベントピンをタップし、詳細モーダルを表示
2. 「participate」ボタンを押すと確認ダイアログが表示される
3. 未参加の場合は参加処理が行われ、「参加しました！」と表示される
4. 既に参加済みの場合は「既に参加しています」と表示される
